### PR TITLE
Update to etk v0.2.0-dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,383 +1,1378 @@
 {
+  "name": "erc20",
+  "lockfileVersion": 2,
   "requires": true,
-  "lockfileVersion": 1,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@truffle/artifactor": "^4.0.94",
+        "ethers": "^5.1.4",
+        "truffle-assertions": "^0.9.2"
+      }
+    },
+    "node_modules/@ethersproject/abi": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.1.tgz",
+      "integrity": "sha512-9mhbjUk76BiSluiiW4BaYyI58KSbDMMQpCLdsAR+RsT2GyATiNYxVv+pGWRrekmsIdY3I+hOqsYQSTkc8L/mcg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-provider": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+      "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/networks": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/web": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-signer": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+      "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/address": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
+      "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/base64": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
+      "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/basex": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.4.0.tgz",
+      "integrity": "sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/bignumber": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.2.tgz",
+      "integrity": "sha512-oIBDhsKy5bs7j36JlaTzFgNPaZjiNDOXsdSgSpXRucUl+UA6L/1YLlFeI3cPAoodcenzF4nxNPV13pcy7XbWjA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "bn.js": "^4.11.9"
+      }
+    },
+    "node_modules/@ethersproject/bytes": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+      "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/constants": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+      "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/contracts": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.4.1.tgz",
+      "integrity": "sha512-m+z2ZgPy4pyR15Je//dUaymRUZq5MtDajF6GwFbGAVmKz/RF+DNIPwF0k5qEcL3wPGVqUjFg2/krlCRVTU4T5w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "^5.4.0",
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/hash": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
+      "integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/hdnode": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.4.0.tgz",
+      "integrity": "sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/basex": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/pbkdf2": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/wordlists": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/json-wallets": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz",
+      "integrity": "sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hdnode": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/pbkdf2": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "aes-js": "3.0.0",
+        "scrypt-js": "3.0.1"
+      }
+    },
+    "node_modules/@ethersproject/keccak256": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+      "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.4.0",
+        "js-sha3": "0.5.7"
+      }
+    },
+    "node_modules/@ethersproject/logger": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
+      "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ]
+    },
+    "node_modules/@ethersproject/networks": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+      "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/pbkdf2": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz",
+      "integrity": "sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/properties": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.1.tgz",
+      "integrity": "sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/providers": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.4.5.tgz",
+      "integrity": "sha512-1GkrvkiAw3Fj28cwi1Sqm8ED1RtERtpdXmRfwIBGmqBSN5MoeRUHuwHPppMtbPayPgpFcvD7/Gdc9doO5fGYgw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/basex": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/networks": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/web": "^5.4.0",
+        "bech32": "1.1.4",
+        "ws": "7.4.6"
+      }
+    },
+    "node_modules/@ethersproject/random": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.4.0.tgz",
+      "integrity": "sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/rlp": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
+      "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/sha2": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.4.0.tgz",
+      "integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/signing-key": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
+      "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "bn.js": "^4.11.9",
+        "elliptic": "6.5.4",
+        "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/solidity": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
+      "integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/strings": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+      "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/transactions": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
+      "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/units": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.4.0.tgz",
+      "integrity": "sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/wallet": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.4.0.tgz",
+      "integrity": "sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/hdnode": "^5.4.0",
+        "@ethersproject/json-wallets": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/wordlists": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/web": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
+      "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/base64": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
+      }
+    },
+    "node_modules/@ethersproject/wordlists": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.4.0.tgz",
+      "integrity": "sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
+      }
+    },
+    "node_modules/@truffle/artifactor": {
+      "version": "4.0.94",
+      "resolved": "https://registry.npmjs.org/@truffle/artifactor/-/artifactor-4.0.94.tgz",
+      "integrity": "sha512-y7Rb2CCxEsLabahBv92W7CBCx7K7jMeeXrtNMGgx3ZNSuQk7Z/i7dwdSkIGQhZuMtxh7PBCDzigDckUVgGnEfA==",
+      "dependencies": {
+        "@truffle/contract-schema": "^3.3.3",
+        "fs-extra": "^8.1.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.merge": "^4.6.2",
+        "source-map-support": "^0.5.19"
+      }
+    },
+    "node_modules/@truffle/contract-schema": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@truffle/contract-schema/-/contract-schema-3.3.3.tgz",
+      "integrity": "sha512-4bvcEoGycopJBPoCiqHP5Q72/1t/ixYS/pVHru+Rzvad641BgvoGrkd4YnyJ+E/MVb4ZLrndL7whmdGqV5B7SA==",
+      "dependencies": {
+        "ajv": "^6.10.0",
+        "crypto-js": "^3.1.9-1",
+        "debug": "^4.1.0"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "node_modules/crypto-js": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+    },
+    "node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/elliptic": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.7.tgz",
+      "integrity": "sha512-iZc5p2nqfWK1sj8RabwsPM28cr37Bpq7ehTQ5rWExBr2Y09Sn1lDKZOED26n+TsZMye7Y6mIgQ/1cwpSD8XZew==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "5.4.1",
+        "@ethersproject/abstract-provider": "5.4.1",
+        "@ethersproject/abstract-signer": "5.4.1",
+        "@ethersproject/address": "5.4.0",
+        "@ethersproject/base64": "5.4.0",
+        "@ethersproject/basex": "5.4.0",
+        "@ethersproject/bignumber": "5.4.2",
+        "@ethersproject/bytes": "5.4.0",
+        "@ethersproject/constants": "5.4.0",
+        "@ethersproject/contracts": "5.4.1",
+        "@ethersproject/hash": "5.4.0",
+        "@ethersproject/hdnode": "5.4.0",
+        "@ethersproject/json-wallets": "5.4.0",
+        "@ethersproject/keccak256": "5.4.0",
+        "@ethersproject/logger": "5.4.1",
+        "@ethersproject/networks": "5.4.2",
+        "@ethersproject/pbkdf2": "5.4.0",
+        "@ethersproject/properties": "5.4.1",
+        "@ethersproject/providers": "5.4.5",
+        "@ethersproject/random": "5.4.0",
+        "@ethersproject/rlp": "5.4.0",
+        "@ethersproject/sha2": "5.4.0",
+        "@ethersproject/signing-key": "5.4.0",
+        "@ethersproject/solidity": "5.4.0",
+        "@ethersproject/strings": "5.4.0",
+        "@ethersproject/transactions": "5.4.0",
+        "@ethersproject/units": "5.4.0",
+        "@ethersproject/wallet": "5.4.0",
+        "@ethersproject/web": "5.4.0",
+        "@ethersproject/wordlists": "5.4.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/js-sha3": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/truffle-assertions": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/truffle-assertions/-/truffle-assertions-0.9.2.tgz",
+      "integrity": "sha512-9g2RhaxU2F8DeWhqoGQvL/bV8QVoSnQ6PY+ZPvYRP5eF7+/8LExb4mjLx/FeliLTjc3Tv1SABG05Gu5qQ/ErmA==",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "lodash.isequal": "^4.5.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  },
   "dependencies": {
     "@ethersproject/abi": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.1.2.tgz",
-      "integrity": "sha512-uMhoQVPX0UtfzTpekYQSEUcJGDgsJ25ifz+SV6PDETWaUFhcR8RNgb1QPTASP13inW8r6iy0/Xdq9D5hK2pNvA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.4.1.tgz",
+      "integrity": "sha512-9mhbjUk76BiSluiiW4BaYyI58KSbDMMQpCLdsAR+RsT2GyATiNYxVv+pGWRrekmsIdY3I+hOqsYQSTkc8L/mcg==",
       "requires": {
-        "@ethersproject/address": "^5.1.0",
-        "@ethersproject/bignumber": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/constants": "^5.1.0",
-        "@ethersproject/hash": "^5.1.0",
-        "@ethersproject/keccak256": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0",
-        "@ethersproject/strings": "^5.1.0"
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "@ethersproject/abstract-provider": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.1.0.tgz",
-      "integrity": "sha512-8dJUnT8VNvPwWhYIau4dwp7qe1g+KgdRm4XTWvjkI9gAT2zZa90WF5ApdZ3vl1r6NDmnn6vUVvyphClRZRteTQ==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+      "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
       "requires": {
-        "@ethersproject/bignumber": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/networks": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0",
-        "@ethersproject/transactions": "^5.1.0",
-        "@ethersproject/web": "^5.1.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/networks": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/web": "^5.4.0"
       }
     },
     "@ethersproject/abstract-signer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.1.0.tgz",
-      "integrity": "sha512-qQDMkjGZSSJSKl6AnfTgmz9FSnzq3iEoEbHTYwjDlEAv+LNP7zd4ixCcVWlWyk+2siud856M5CRhAmPdupeN9w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+      "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.1.0",
-        "@ethersproject/bignumber": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0"
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0"
       }
     },
     "@ethersproject/address": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.1.0.tgz",
-      "integrity": "sha512-rfWQR12eHn2cpstCFS4RF7oGjfbkZb0oqep+BfrT+gWEGWG2IowJvIsacPOvzyS1jhNF4MQ4BS59B04Mbovteg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
+      "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
       "requires": {
-        "@ethersproject/bignumber": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/keccak256": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/rlp": "^5.1.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0"
       }
     },
     "@ethersproject/base64": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.1.0.tgz",
-      "integrity": "sha512-npD1bLvK4Bcxz+m4EMkx+F8Rd7CnqS9DYnhNu0/GlQBXhWjvfoAZzk5HJ0f1qeyp8d+A86PTuzLOGOXf4/CN8g==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
+      "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0"
+        "@ethersproject/bytes": "^5.4.0"
       }
     },
     "@ethersproject/basex": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.1.0.tgz",
-      "integrity": "sha512-vBKr39bum7DDbOvkr1Sj19bRMEPA4FnST6Utt6xhDzI7o7L6QNkDn2yrCfP+hnvJGhZFKtLygWwqlTBZoBXYLg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.4.0.tgz",
+      "integrity": "sha512-J07+QCVJ7np2bcpxydFVf/CuYo9mZ7T73Pe7KQY4c1lRlrixMeblauMxHXD0MPwFmUHZIILDNViVkykFBZylbg==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0"
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.1.1.tgz",
-      "integrity": "sha512-AVz5iqz7+70RIqoQTznsdJ6DOVBYciNlvO+AlQmPTB6ofCvoihI9bQdr6wljsX+d5W7Yc4nyvQvP4JMzg0Agig==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.2.tgz",
+      "integrity": "sha512-oIBDhsKy5bs7j36JlaTzFgNPaZjiNDOXsdSgSpXRucUl+UA6L/1YLlFeI3cPAoodcenzF4nxNPV13pcy7XbWjA==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "bn.js": "^4.4.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "bn.js": "^4.11.9"
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.1.0.tgz",
-      "integrity": "sha512-sGTxb+LVjFxJcJeUswAIK6ncgOrh3D8c192iEJd7mLr95V6du119rRfYT/b87WPkZ5I3gRBUYIYXtdgCWACe8g==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+      "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
       "requires": {
-        "@ethersproject/logger": "^5.1.0"
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/constants": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.1.0.tgz",
-      "integrity": "sha512-0/SuHrxc8R8k+JiLmJymxHJbojUDWBQqO+b+XFdwaP0jGzqC09YDy/CAlSZB6qHsBifY8X3I89HcK/oMqxRdBw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+      "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
       "requires": {
-        "@ethersproject/bignumber": "^5.1.0"
+        "@ethersproject/bignumber": "^5.4.0"
       }
     },
     "@ethersproject/contracts": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.1.1.tgz",
-      "integrity": "sha512-6WwktLJ0DFWU8pDkgH4IGttQHhQN4SnwKFu9h+QYVe48VGWtbDu4W8/q/7QA1u/HWlWMrKxqawPiZUJj0UMvOw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.4.1.tgz",
+      "integrity": "sha512-m+z2ZgPy4pyR15Je//dUaymRUZq5MtDajF6GwFbGAVmKz/RF+DNIPwF0k5qEcL3wPGVqUjFg2/krlCRVTU4T5w==",
       "requires": {
-        "@ethersproject/abi": "^5.1.0",
-        "@ethersproject/abstract-provider": "^5.1.0",
-        "@ethersproject/abstract-signer": "^5.1.0",
-        "@ethersproject/address": "^5.1.0",
-        "@ethersproject/bignumber": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/constants": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0",
-        "@ethersproject/transactions": "^5.1.0"
+        "@ethersproject/abi": "^5.4.0",
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0"
       }
     },
     "@ethersproject/hash": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.1.0.tgz",
-      "integrity": "sha512-fNwry20yLLPpnRRwm3fBL+2ksgO+KMadxM44WJmRIoTKzy4269+rbq9KFoe2LTqq2CXJM2CE70beGaNrpuqflQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.4.0.tgz",
+      "integrity": "sha512-xymAM9tmikKgbktOCjW60Z5sdouiIIurkZUr9oW5NOex5uwxrbsYG09kb5bMcNjlVeJD3yPivTNzViIs1GCbqA==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.1.0",
-        "@ethersproject/address": "^5.1.0",
-        "@ethersproject/bignumber": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/keccak256": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0",
-        "@ethersproject/strings": "^5.1.0"
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "@ethersproject/hdnode": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.1.0.tgz",
-      "integrity": "sha512-obIWdlujloExPHWJGmhJO/sETOOo7SEb6qemV4f8kyFoXg+cJK+Ta9SvBrj7hsUK85n3LZeZJZRjjM7oez3Clg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.4.0.tgz",
+      "integrity": "sha512-pKxdS0KAaeVGfZPp1KOiDLB0jba11tG6OP1u11QnYfb7pXn6IZx0xceqWRr6ygke8+Kw74IpOoSi7/DwANhy8Q==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.1.0",
-        "@ethersproject/basex": "^5.1.0",
-        "@ethersproject/bignumber": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/pbkdf2": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0",
-        "@ethersproject/sha2": "^5.1.0",
-        "@ethersproject/signing-key": "^5.1.0",
-        "@ethersproject/strings": "^5.1.0",
-        "@ethersproject/transactions": "^5.1.0",
-        "@ethersproject/wordlists": "^5.1.0"
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/basex": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/pbkdf2": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/wordlists": "^5.4.0"
       }
     },
     "@ethersproject/json-wallets": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.1.0.tgz",
-      "integrity": "sha512-00n2iBy27w8zrGZSiU762UOVuzCQZxUZxopsZC47++js6xUFuI74DHcJ5K/2pddlF1YBskvmMuboEu1geK8mnA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.4.0.tgz",
+      "integrity": "sha512-igWcu3fx4aiczrzEHwG1xJZo9l1cFfQOWzTqwRw/xcvxTk58q4f9M7cjh51EKphMHvrJtcezJ1gf1q1AUOfEQQ==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.1.0",
-        "@ethersproject/address": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/hdnode": "^5.1.0",
-        "@ethersproject/keccak256": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/pbkdf2": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0",
-        "@ethersproject/random": "^5.1.0",
-        "@ethersproject/strings": "^5.1.0",
-        "@ethersproject/transactions": "^5.1.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hdnode": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/pbkdf2": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.1.0.tgz",
-      "integrity": "sha512-vrTB1W6AEYoadww5c9UyVJ2YcSiyIUTNDRccZIgwTmFFoSHwBtcvG1hqy9RzJ1T0bMdATbM9Hfx2mJ6H0i7Hig==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+      "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/bytes": "^5.4.0",
         "js-sha3": "0.5.7"
       }
     },
     "@ethersproject/logger": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.1.0.tgz",
-      "integrity": "sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw=="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
+      "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A=="
     },
     "@ethersproject/networks": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.1.0.tgz",
-      "integrity": "sha512-A/NIrIED/G/IgU1XUukOA3WcFRxn2I4O5GxsYGA5nFlIi+UZWdGojs85I1VXkR1gX9eFnDXzjE6OtbgZHjFhIA==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+      "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
       "requires": {
-        "@ethersproject/logger": "^5.1.0"
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/pbkdf2": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.1.0.tgz",
-      "integrity": "sha512-B8cUbHHTgs8OtgJIafrRcz/YPDobVd5Ru8gTnShOiM9EBuFpYHQpq3+8iQJ6pyczDu6HP/oc/njAsIBhwFZYew==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.4.0.tgz",
+      "integrity": "sha512-x94aIv6tiA04g6BnazZSLoRXqyusawRyZWlUhKip2jvoLpzJuLb//KtMM6PEovE47pMbW+Qe1uw+68ameJjB7g==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/sha2": "^5.1.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0"
       }
     },
     "@ethersproject/properties": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.1.0.tgz",
-      "integrity": "sha512-519KKTwgmH42AQL3+GFV3SX6khYEfHsvI6v8HYejlkigSDuqttdgVygFTDsGlofNFchhDwuclrxQnD5B0YLNMg==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.1.tgz",
+      "integrity": "sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==",
       "requires": {
-        "@ethersproject/logger": "^5.1.0"
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/providers": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.1.2.tgz",
-      "integrity": "sha512-GqsS8rd+eyd4eNkcNgzZ4l9IRULBPUZa7JPnv22k4MHflMobUseyhfbVnmoN5bVNNkOxjV1IPTw9i0sV1hwdpg==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.4.5.tgz",
+      "integrity": "sha512-1GkrvkiAw3Fj28cwi1Sqm8ED1RtERtpdXmRfwIBGmqBSN5MoeRUHuwHPppMtbPayPgpFcvD7/Gdc9doO5fGYgw==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.1.0",
-        "@ethersproject/abstract-signer": "^5.1.0",
-        "@ethersproject/address": "^5.1.0",
-        "@ethersproject/basex": "^5.1.0",
-        "@ethersproject/bignumber": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/constants": "^5.1.0",
-        "@ethersproject/hash": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/networks": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0",
-        "@ethersproject/random": "^5.1.0",
-        "@ethersproject/rlp": "^5.1.0",
-        "@ethersproject/sha2": "^5.1.0",
-        "@ethersproject/strings": "^5.1.0",
-        "@ethersproject/transactions": "^5.1.0",
-        "@ethersproject/web": "^5.1.0",
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/basex": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/networks": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/web": "^5.4.0",
         "bech32": "1.1.4",
-        "ws": "7.2.3"
+        "ws": "7.4.6"
       }
     },
     "@ethersproject/random": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.1.0.tgz",
-      "integrity": "sha512-+uuczLQZ4+no9cP6TCoCktXx0u2YbNaRT7lRkSt12d8263e702f0u+4JnnRO8Qmv5nylWJebnqCHzyxP+6mLqw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.4.0.tgz",
+      "integrity": "sha512-pnpWNQlf0VAZDEOVp1rsYQosmv2o0ITS/PecNw+mS2/btF8eYdspkN0vIXrCMtkX09EAh9bdk8GoXmFXM1eAKw==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/rlp": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.1.0.tgz",
-      "integrity": "sha512-vDTyHIwNPrecy55gKGZ47eJZhBm8LLBxihzi5ou+zrSvYTpkSTWRcKUlXFDFQVwfWB+P5PGyERAdiDEI76clxw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
+      "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/sha2": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.1.0.tgz",
-      "integrity": "sha512-+fNSeZRstOpdRJpdGUkRONFCaiAqWkc91zXgg76Nlp5ndBQE25Kk5yK8gCPG1aGnCrbariiPr5j9DmrYH78JCA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.4.0.tgz",
+      "integrity": "sha512-siheo36r1WD7Cy+bDdE1BJ8y0bDtqXCOxRMzPa4bV1TGt/eTUUt03BHoJNB6reWJD8A30E/pdJ8WFkq+/uz4Gg==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "hash.js": "1.1.3"
-      },
-      "dependencies": {
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        }
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "hash.js": "1.1.7"
       }
     },
     "@ethersproject/signing-key": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.1.0.tgz",
-      "integrity": "sha512-tE5LFlbmdObG8bY04NpuwPWSRPgEswfxweAI1sH7TbP0ml1elNfqcq7ii/3AvIN05i5U0Pkm3Tf8bramt8MmLw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
+      "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0",
-        "bn.js": "^4.4.0",
-        "elliptic": "6.5.4"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "bn.js": "^4.11.9",
+        "elliptic": "6.5.4",
+        "hash.js": "1.1.7"
       }
     },
     "@ethersproject/solidity": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.1.0.tgz",
-      "integrity": "sha512-kPodsGyo9zg1g9XSXp1lGhFaezBAUUsAUB1Vf6OkppE5Wksg4Et+x3kG4m7J/uShDMP2upkJtHNsIBK2XkVpKQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
+      "integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
       "requires": {
-        "@ethersproject/bignumber": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/keccak256": "^5.1.0",
-        "@ethersproject/sha2": "^5.1.0",
-        "@ethersproject/strings": "^5.1.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/sha2": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "@ethersproject/strings": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.1.0.tgz",
-      "integrity": "sha512-perBZy0RrmmL0ejiFGUOlBVjMsUceqLut3OBP3zP96LhiJWWbS8u1NqQVgN4/Gyrbziuda66DxiQocXhsvx+Sw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+      "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/constants": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/transactions": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.1.1.tgz",
-      "integrity": "sha512-Nwgbp09ttIVN0OoUBatCXaHxR7grWPHbozJN8v7AXDLrl6nnOIBEMDh+yJTnosSQlFhcyjfTGGN+Mx6R8HdvMw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
+      "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
       "requires": {
-        "@ethersproject/address": "^5.1.0",
-        "@ethersproject/bignumber": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/constants": "^5.1.0",
-        "@ethersproject/keccak256": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0",
-        "@ethersproject/rlp": "^5.1.0",
-        "@ethersproject/signing-key": "^5.1.0"
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0"
       }
     },
     "@ethersproject/units": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.1.0.tgz",
-      "integrity": "sha512-isvJrx6qG0nKWfxsGORNjmOq/nh175fStfvRTA2xEKrGqx8JNJY83fswu4GkILowfriEM/eYpretfJnfzi7YhA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.4.0.tgz",
+      "integrity": "sha512-Z88krX40KCp+JqPCP5oPv5p750g+uU6gopDYRTBGcDvOASh6qhiEYCRatuM/suC4S2XW9Zz90QI35MfSrTIaFg==",
       "requires": {
-        "@ethersproject/bignumber": "^5.1.0",
-        "@ethersproject/constants": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/wallet": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.1.0.tgz",
-      "integrity": "sha512-ULmUtiYQLTUS+y3DgkLzRhFEK10zMwmjOthnjiZxee3Q/MVwr3rnmuAnXIUZrPjna6hvUPnyRIdW5XuF0Ld0YQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.4.0.tgz",
+      "integrity": "sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.1.0",
-        "@ethersproject/abstract-signer": "^5.1.0",
-        "@ethersproject/address": "^5.1.0",
-        "@ethersproject/bignumber": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/hash": "^5.1.0",
-        "@ethersproject/hdnode": "^5.1.0",
-        "@ethersproject/json-wallets": "^5.1.0",
-        "@ethersproject/keccak256": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0",
-        "@ethersproject/random": "^5.1.0",
-        "@ethersproject/signing-key": "^5.1.0",
-        "@ethersproject/transactions": "^5.1.0",
-        "@ethersproject/wordlists": "^5.1.0"
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/abstract-signer": "^5.4.0",
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/hdnode": "^5.4.0",
+        "@ethersproject/json-wallets": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/random": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/wordlists": "^5.4.0"
       }
     },
     "@ethersproject/web": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.1.0.tgz",
-      "integrity": "sha512-LTeluWgTq04+RNqAkVhpydPcRZK/kKxD2Vy7PYGrAD27ABO9kTqTBKwiOuzTyAHKUQHfnvZbXmxBXJAGViSDcA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
+      "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
       "requires": {
-        "@ethersproject/base64": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0",
-        "@ethersproject/strings": "^5.1.0"
+        "@ethersproject/base64": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "@ethersproject/wordlists": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.1.0.tgz",
-      "integrity": "sha512-NsUCi/TpBb+oTFvMSccUkJGtp5o/84eOyqp5q5aBeiNBSLkYyw21znRn9mAmxZgySpxgruVgKbaapnYPgvctPQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.4.0.tgz",
+      "integrity": "sha512-FemEkf6a+EBKEPxlzeVgUaVSodU7G0Na89jqKjmWMlDB0tomoU8RlEMgUvXyqtrg8N4cwpLh8nyRnm1Nay1isA==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/hash": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0",
-        "@ethersproject/strings": "^5.1.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/hash": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "@truffle/artifactor": {
@@ -471,40 +1466,40 @@
       }
     },
     "ethers": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.1.4.tgz",
-      "integrity": "sha512-EAPQ/fgGRu0PoR/VNFnHTMOtG/IZ0AItdW55C9T8ffmVu0rnyllZL404eBF66elJehOLz2kxnUrhXpE7TCpW7g==",
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.7.tgz",
+      "integrity": "sha512-iZc5p2nqfWK1sj8RabwsPM28cr37Bpq7ehTQ5rWExBr2Y09Sn1lDKZOED26n+TsZMye7Y6mIgQ/1cwpSD8XZew==",
       "requires": {
-        "@ethersproject/abi": "5.1.2",
-        "@ethersproject/abstract-provider": "5.1.0",
-        "@ethersproject/abstract-signer": "5.1.0",
-        "@ethersproject/address": "5.1.0",
-        "@ethersproject/base64": "5.1.0",
-        "@ethersproject/basex": "5.1.0",
-        "@ethersproject/bignumber": "5.1.1",
-        "@ethersproject/bytes": "5.1.0",
-        "@ethersproject/constants": "5.1.0",
-        "@ethersproject/contracts": "5.1.1",
-        "@ethersproject/hash": "5.1.0",
-        "@ethersproject/hdnode": "5.1.0",
-        "@ethersproject/json-wallets": "5.1.0",
-        "@ethersproject/keccak256": "5.1.0",
-        "@ethersproject/logger": "5.1.0",
-        "@ethersproject/networks": "5.1.0",
-        "@ethersproject/pbkdf2": "5.1.0",
-        "@ethersproject/properties": "5.1.0",
-        "@ethersproject/providers": "5.1.2",
-        "@ethersproject/random": "5.1.0",
-        "@ethersproject/rlp": "5.1.0",
-        "@ethersproject/sha2": "5.1.0",
-        "@ethersproject/signing-key": "5.1.0",
-        "@ethersproject/solidity": "5.1.0",
-        "@ethersproject/strings": "5.1.0",
-        "@ethersproject/transactions": "5.1.1",
-        "@ethersproject/units": "5.1.0",
-        "@ethersproject/wallet": "5.1.0",
-        "@ethersproject/web": "5.1.0",
-        "@ethersproject/wordlists": "5.1.0"
+        "@ethersproject/abi": "5.4.1",
+        "@ethersproject/abstract-provider": "5.4.1",
+        "@ethersproject/abstract-signer": "5.4.1",
+        "@ethersproject/address": "5.4.0",
+        "@ethersproject/base64": "5.4.0",
+        "@ethersproject/basex": "5.4.0",
+        "@ethersproject/bignumber": "5.4.2",
+        "@ethersproject/bytes": "5.4.0",
+        "@ethersproject/constants": "5.4.0",
+        "@ethersproject/contracts": "5.4.1",
+        "@ethersproject/hash": "5.4.0",
+        "@ethersproject/hdnode": "5.4.0",
+        "@ethersproject/json-wallets": "5.4.0",
+        "@ethersproject/keccak256": "5.4.0",
+        "@ethersproject/logger": "5.4.1",
+        "@ethersproject/networks": "5.4.2",
+        "@ethersproject/pbkdf2": "5.4.0",
+        "@ethersproject/properties": "5.4.1",
+        "@ethersproject/providers": "5.4.5",
+        "@ethersproject/random": "5.4.0",
+        "@ethersproject/rlp": "5.4.0",
+        "@ethersproject/sha2": "5.4.0",
+        "@ethersproject/signing-key": "5.4.0",
+        "@ethersproject/solidity": "5.4.0",
+        "@ethersproject/strings": "5.4.0",
+        "@ethersproject/transactions": "5.4.0",
+        "@ethersproject/units": "5.4.0",
+        "@ethersproject/wallet": "5.4.0",
+        "@ethersproject/web": "5.4.0",
+        "@ethersproject/wordlists": "5.4.0"
       }
     },
     "fast-deep-equal": {
@@ -651,9 +1646,10 @@
       }
     },
     "ws": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
-      "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "requires": {}
     }
   }
 }

--- a/src/allowance.etk
+++ b/src/allowance.etk
@@ -1,19 +1,19 @@
-; allowance
-;
-; calldata structure
-; +--------------------+------------------+------------------+------------------+--------------------+
-; | selector (4 bytes) | zeros (12 bytes) | owner (20 bytes) | zeros (20 bytes) | spender (20 bytes) |
-; +--------------------+------------------+------------------+------------------+--------------------+
+# allowance
+#
+# calldata structure
+# +--------------------+------------------+------------------+------------------+--------------------+
+# | selector (4 bytes) | zeros (12 bytes) | owner (20 bytes) | zeros (20 bytes) | spender (20 bytes) |
+# +--------------------+------------------+------------------+------------------+--------------------+
 
-push1 64		; [len]
-push1 4			; [offset]
-keccak256		; [key]
+push1 64		# [len]
+push1 4			# [offset]
+keccak256		# [key]
 
-sload			; [allowance]
-push1 0			; [offset, allowance]
-mstore			; []
+sload			# [allowance]
+push1 0			# [offset, allowance]
+mstore			# []
 
-push1 32		; [32]
-push1 0			; [0, 32]
+push1 32		# [32]
+push1 0			# [0, 32]
 
-return			; []
+return			# []

--- a/src/approve.etk
+++ b/src/approve.etk
@@ -1,48 +1,48 @@
-; approve
-;
-; calldata structure
-; +--------------------+------------------+--------------------+-------------------+
-; | selector (4 bytes) | zeros (12 bytes) | spender (20 bytes) | amount (32 bytes) |
-; +--------------------+------------------+--------------------+-------------------+
+# approve
+#
+# calldata structure
+# +--------------------+------------------+--------------------+-------------------+
+# | selector (4 bytes) | zeros (12 bytes) | spender (20 bytes) | amount (32 bytes) |
+# +--------------------+------------------+--------------------+-------------------+
 
-push1 36		; [36]
-mload			; [amt]
+push1 36		# [36]
+mload			# [amt]
 
-push1 4			; [4, amt]
-mload			; [sender, amt]
+push1 4			# [4, amt]
+mload			# [sender, amt]
 
-; write the sender to mem[36..68]
-push1 36		; [36, sender, amt]
-mstore			; [amt]
+# write the sender to mem[36..68]
+push1 36		# [36, sender, amt]
+mstore			# [amt]
 
-; write the caller to mem[4..36]
-caller			; [caller, amt]
-push1 4			; [4, caller, amt]
-mstore			; [amt]
+# write the caller to mem[4..36]
+caller			# [caller, amt]
+push1 4			# [4, caller, amt]
+mstore			# [amt]
 
-; hash mem[4..68]
-push1 64		; [len, amt]
-push1 4			; [offset, len, amt]
-keccak256		; [key, amt]
-dup1			; [key, key, amt]
+# hash mem[4..68]
+push1 64		# [len, amt]
+push1 4			# [offset, len, amt]
+keccak256		# [key, amt]
+dup1			# [key, key, amt]
 
-sload			; [allowance, key, amt]
-swap1			; [key, allowance, amt]
-swap2			; [amt, allowance, key]
-add			; [new_allowance, key]
-swap1			; [key, new_allowance]
-sstore			; []
+sload			# [allowance, key, amt]
+swap1			# [key, allowance, amt]
+swap2			# [amt, allowance, key]
+add			# [new_allowance, key]
+swap1			# [key, new_allowance]
+sstore			# []
 
-; output event
-push1 4			; [4]
-calldataload		; [spender]
-caller			; [owner, spender]
-push1 36		; [36, owner, spender]
-calldataload		; [amt, owner, spender]
-push1 0			; [0, value, owner, spender]
-mstore			; [owner, spender]
-push32 selector("Approval(address,address,uint256)") ; [topic, owner, spender]
-push1 32		; [32, topic, owner, spender]
-push1 0			; [0, 32, topic, ownder, spender]
+# output event
+push1 4			# [4]
+calldataload		# [spender]
+caller			# [owner, spender]
+push1 36		# [36, owner, spender]
+calldataload		# [amt, owner, spender]
+push1 0			# [0, value, owner, spender]
+mstore			# [owner, spender]
+push32 topic("Approval(address,address,uint256)") # [topic, owner, spender]
+push1 32		# [32, topic, owner, spender]
+push1 0			# [0, 32, topic, ownder, spender]
 
-log3			; []
+log3			# []

--- a/src/balance_of.etk
+++ b/src/balance_of.etk
@@ -1,23 +1,23 @@
-; balance_of
-;
-; calldata structure
-; +--------------------+------------------+--------------------+
-; | selector (4 bytes) | zeros (12 bytes) | address (20 bytes) |
-; +--------------------+------------------+--------------------+
+# balance_of
+#
+# calldata structure
+# +--------------------+------------------+--------------------+
+# | selector (4 bytes) | zeros (12 bytes) | address (20 bytes) |
+# +--------------------+------------------+--------------------+
 
-; prepare return parameters
-push1 32		; [ret_len]
-push1 0			; [ret_offset, ret_len]
+# prepare return parameters
+push1 32		# [ret_len]
+push1 0			# [ret_offset, ret_len]
 
-; skip the selector, load the address
-push1 4			; [4, ret_offset, ret_len]
-mload			; [addr, ret_offset, ret_len]
+# skip the selector, load the address
+push1 4			# [4, ret_offset, ret_len]
+mload			# [addr, ret_offset, ret_len]
 
-; load balance
-sload			; [balance, ret_offset, ret_len]
+# load balance
+sload			# [balance, ret_offset, ret_len]
 
-; prepare balance to return
-dup2			; [0, balance, ret_offset, ret_len]
-mstore			; [ret_offset, ret_len]
+# prepare balance to return
+dup2			# [0, balance, ret_offset, ret_len]
+mstore			# [ret_offset, ret_len]
 
-return			; []
+return			# []

--- a/src/ctor.etk
+++ b/src/ctor.etk
@@ -1,21 +1,21 @@
-pc                              ; [0]
+pc                              # [0]
 
-; give deployer initial supply
-push4 10000			; [balance, 0]
-caller				; [caller, balance, 0]
-sstore				; [0]
+# give deployer initial supply
+push4 10000			# [balance, 0]
+caller				# [caller, balance, 0]
+sstore				# [0]
 
-push1 start                     ; [start, 0]
-dup1                            ; [start, start, 0]
-codesize                        ; [codesize, start, start, 0]
-sub                             ; [length, start, 0]
-swap2                           ; [0, start, length]
-swap1                           ; [start, 0, length]
-dup3                            ; [length, start, 0, length]
-swap1                           ; [start, length, 0, length]
-dup3                            ; [0, start, length, 0, length]
-codecopy                        ; [0, length]
-return                          ; []
+push1 start                     # [start, 0]
+dup1                            # [start, start, 0]
+codesize                        # [codesize, start, start, 0]
+sub                             # [length, start, 0]
+swap2                           # [0, start, length]
+swap1                           # [start, 0, length]
+dup3                            # [length, start, 0, length]
+swap1                           # [start, length, 0, length]
+dup3                            # [0, start, length, 0, length]
+codecopy                        # [0, length]
+return                          # []
 
 start:
 %include("jump_table.etk")

--- a/src/jump_table.etk
+++ b/src/jump_table.etk
@@ -1,73 +1,73 @@
-;
-; erc20
-;
-; Minimal ERC-20 implementation in raw assembly.
-;
-; Storage Layout
-; --
-; balance(address)	    => 0x000000000000000000000000 || address
-; allowance(owner, spender) => keccak(owner || spender)
+#
+# erc20
+#
+# Minimal ERC-20 implementation in raw assembly.
+#
+# Storage Layout
+# --
+# balance(address)	    => 0x000000000000000000000000 || address
+# allowance(owner, spender) => keccak(owner || spender)
 
 
 start:
-	; Read the calldata into memory.
-	calldatasize		; [calldatasize]
-	push1 0			; [0, calldatasize]
-	dup1			; [0, 0, calldatasize]
-	calldatacopy		; []
+	# Read the calldata into memory.
+	calldatasize		# [calldatasize]
+	push1 0			# [0, calldatasize]
+	dup1			# [0, 0, calldatasize]
+	calldatacopy		# []
 
-	; Extract only the function selector
-	push1 0			; [0]
-	mload			; [dirty_selector]
-	push1 224		; [224, dirty_selector]
-	shr		      	; [selector]
+	# Extract only the function selector
+	push1 0			# [0]
+	mload			# [dirty_selector]
+	push1 224		# [224, dirty_selector]
+	shr		      	# [selector]
 
-	; Jump to the coresponding function.
-	dup1			; [selector, selector]
-	push4 selector("transferFrom(address,address,uint256)") ; [candidate, selector, selector]
-	eq			; [success, selector]
-	push4 transfer_from	; [transfer_from, success, selector]
-	jumpi			; [selector]
+	# Jump to the coresponding function.
+	dup1			# [selector, selector]
+	push4 selector("transferFrom(address,address,uint256)") # [candidate, selector, selector]
+	eq			# [success, selector]
+	push4 transfer_from	# [transfer_from, success, selector]
+	jumpi			# [selector]
 
-	dup1			; [selector, selector]
-	push4 selector("approve(address,uint256)") ; [candidate, selector, selector]
-	eq			; [success, selector]
-	push4 approve		; [allowance, success, selector]
-	jumpi			; [selector]
+	dup1			# [selector, selector]
+	push4 selector("approve(address,uint256)") # [candidate, selector, selector]
+	eq			# [success, selector]
+	push4 approve		# [allowance, success, selector]
+	jumpi			# [selector]
 
-	dup1			; [selector, selector]
-	push4 selector("transfer(address,uint256)") ; [candidate, selector, selector]
-	eq			; [selector, success]
-	push4 transfer		; [transfer, success, selector]
-	jumpi			; [selector]
+	dup1			# [selector, selector]
+	push4 selector("transfer(address,uint256)") # [candidate, selector, selector]
+	eq			# [selector, success]
+	push4 transfer		# [transfer, success, selector]
+	jumpi			# [selector]
 
 
-	; Check the view functions last to not waste gas on-chain.
-	dup1			; [selector, selector]
-	push4 selector("decimals()") ; [candidate, selector, selector]
-	eq			; [success, selector]
-	push4 decimals		; [decimals, success, selector]
-	jumpi			; [selector]
+	# Check the view functions last to not waste gas on-chain.
+	dup1			# [selector, selector]
+	push4 selector("decimals()") # [candidate, selector, selector]
+	eq			# [success, selector]
+	push4 decimals		# [decimals, success, selector]
+	jumpi			# [selector]
 
-	dup1			; [selector, selector]
-	push4 selector("totalSupply()")	; [candidate, selector, selector]
-	eq			; [success, selector]
-	push4 total_supply	; [total_supply, success, selector]
-	jumpi			; [selector]
+	dup1			# [selector, selector]
+	push4 selector("totalSupply()")	# [candidate, selector, selector]
+	eq			# [success, selector]
+	push4 total_supply	# [total_supply, success, selector]
+	jumpi			# [selector]
 
-	dup1			; [selector, selector]
-	push4 selector("balanceOf(address)") ; [candidate, selector, selector]
-	eq			; [success, selector]
-	push4 balance_of	; [balance_of, success, selector]
-	jumpi			; [selector]
+	dup1			# [selector, selector]
+	push4 selector("balanceOf(address)") # [candidate, selector, selector]
+	eq			# [success, selector]
+	push4 balance_of	# [balance_of, success, selector]
+	jumpi			# [selector]
 
-	dup1			; [selector, selector]
-	push4 selector("allowance(address,address)") ; [candidate, selector, selector]
-	eq			; [success, selector]
-	push4 allowance		; [allowance, success, selector]
-	jumpi			; [selector]
+	dup1			# [selector, selector]
+	push4 selector("allowance(address,address)") # candidate, selector, selector]
+	eq			# [success, selector]
+	push4 allowance		# [allowance, success, selector]
+	jumpi			# [selector]
 
-; Catchall for reverts.
+# Catchall for reverts.
 failure:
 	jumpdest
 	push1 0

--- a/src/transfer.etk
+++ b/src/transfer.etk
@@ -1,49 +1,49 @@
-; transfer
-;
-; calldata structure
-; +--------------------+------------------+---------------+-------------------+
-; | selector (4 bytes) | zeros (12 bytes) | to (20 bytes) | amount (32 bytes) |
-; +--------------------+------------------+---------------+-------------------+
+# transfer
+#
+# calldata structure
+# +--------------------+------------------+---------------+-------------------+
+# | selector (4 bytes) | zeros (12 bytes) | to (20 bytes) | amount (32 bytes) |
+# +--------------------+------------------+---------------+-------------------+
 
-caller			; [from]
-sload			; [from_balance]
-push1 36		; [36, from_balance]
-mload			; [amt, from_balance]
-dup2			; [from_balance, amt, from_balance]
-dup2			; [amt, from_balance, amt, from_balance]
+caller			# [from]
+sload			# [from_balance]
+push1 36		# [36, from_balance]
+mload			# [amt, from_balance]
+dup2			# [from_balance, amt, from_balance]
+dup2			# [amt, from_balance, amt, from_balance]
 
-; if amt > from_balance, revert
-gt			; [amt > from_balance, amt, from_balance]
-push4 failure		; [failure, from_balance, amt, from_balance]
-jumpi			; [amt, from_balance]
+# if amt > from_balance, revert
+gt			# [amt > from_balance, amt, from_balance]
+push4 failure		# [failure, from_balance, amt, from_balance]
+jumpi			# [amt, from_balance]
 
-; sstore(from, from_balance - amt)
-swap1			; [from_balance, amt]
-sub			; [from_balance - amt]
-caller			; [from, from_balance - amt]
-sstore			; []
+# sstore(from, from_balance - amt)
+swap1			# [from_balance, amt]
+sub			# [from_balance - amt]
+caller			# [from, from_balance - amt]
+sstore			# []
 
-; sstore(to, to_balance + amt)
-push1 4			; [4]
-mload			; [to]
-dup1			; [to, to]
-sload			; [to_balance, to]
-push1 36		; [36, to_balance, to]
-mload			; [amt, to_balance, to]
-add			; [amt + to_balance, to]
-swap1			; [to, amt + to_balance]
-sstore			; []
+# sstore(to, to_balance + amt)
+push1 4			# [4]
+mload			# [to]
+dup1			# [to, to]
+sload			# [to_balance, to]
+push1 36		# [36, to_balance, to]
+mload			# [amt, to_balance, to]
+add			# [amt + to_balance, to]
+swap1			# [to, amt + to_balance]
+sstore			# []
 
-; output event
-push1 4			; [4]
-calldataload		; [to]
-caller			; [from, to]
-push1 36		; [36, from, to]
-calldataload		; [amt, from, to]
-push1 0			; [0, amt, from, to]
-mstore			; [from, to]
-push32 selector("Transfer(address,address,uint256)") ; [topic, from, to]
-push1 32		; [32, topic, from, to]
-push1 0			; [0, 32, topic, from, to]
+# output event
+push1 4			# [4]
+calldataload		# [to]
+caller			# [from, to]
+push1 36		# [36, from, to]
+calldataload		# [amt, from, to]
+push1 0			# [0, amt, from, to]
+mstore			# [from, to]
+push32 topic("Transfer(address,address,uint256)") # [topic, from, to]
+push1 32		# [32, topic, from, to]
+push1 0			# [0, 32, topic, from, to]
 
-log3			; []
+log3			# []

--- a/src/transfer_from.etk
+++ b/src/transfer_from.etk
@@ -1,84 +1,84 @@
-; transfer_from
-;
-; calldata structure
-; +--------------------+-----------------+---------------+-------------------+
-; | selector (4 bytes) | from (32 bytes) | to (32 bytes) | amount (32 bytes) |
-; +--------------------+-----------------+---------------+-------------------+
+# transfer_from
+#
+# calldata structure
+# +--------------------+-----------------+---------------+-------------------+
+# | selector (4 bytes) | from (32 bytes) | to (32 bytes) | amount (32 bytes) |
+# +--------------------+-----------------+---------------+-------------------+
 
-push1 64		; [len]
-push1 4			; [offset, len]
-keccak256		; [key]
-dup1			; [key, key]
+push1 64		# [len]
+push1 4			# [offset, len]
+keccak256		# [key]
+dup1			# [key, key]
 
-sload			; [available, key]
+sload			# [available, key]
 
-push1 68		; [68, available, key]
-mload			; [amt, available, key]
+push1 68		# [68, available, key]
+mload			# [amt, available, key]
 
-; if amt > available, revert
-dup2			; [available, amt, available, key]
-dup2			; [amt, available, amt, available, key]
-gt			; [amt > available, amt, available, key]
-push4 failure		; [failure, amt > available, amt, available, key]
-jumpi			; [amt, available, key]
+# if amt > available, revert
+dup2			# [available, amt, available, key]
+dup2			# [amt, available, amt, available, key]
+gt			# [amt > available, amt, available, key]
+push4 failure		# [failure, amt > available, amt, available, key]
+jumpi			# [amt, available, key]
 
 check_sender:
-jumpdest		; [amt, available, key]
-push1 4			; [4, amt, available, key]
-calldataload		; [from, amt, available, key]
-sload			; [from_balance, amt, available, key]
+jumpdest		# [amt, available, key]
+push1 4			# [4, amt, available, key]
+calldataload		# [from, amt, available, key]
+sload			# [from_balance, amt, available, key]
 
-lt			; [from_balance < amt, available, key]
-push4 failure		; [failure, from_balance < amt, available, key]
-jumpi			; [available, key]
+lt			# [from_balance < amt, available, key]
+push4 failure		# [failure, from_balance < amt, available, key]
+jumpi			# [available, key]
 
-; reduce allowance by amt
-push4 68		; [68, available, key]
-calldataload		; [amt, available, key]
-swap1			; [available, amt, key]
-sub			; [available - amt, key]
-swap1			; [key, available - amt]
-sstore			; []
+# reduce allowance by amt
+push4 68		# [68, available, key]
+calldataload		# [amt, available, key]
+swap1			# [available, amt, key]
+sub			# [available - amt, key]
+swap1			# [key, available - amt]
+sstore			# []
 
-; reduce from balance by amt
-push4 4			; [4]
-calldataload		; [from]
-dup1			; [from, from]
-sload			; [from_balance, from]
+# reduce from balance by amt
+push4 4			# [4]
+calldataload		# [from]
+dup1			# [from, from]
+sload			# [from_balance, from]
 
-push1 68		; [68, from_balance, from]
-calldataload		; [amt, from_balance, from]
-dup1			; [amt, amt, from_balance, from]
+push1 68		# [68, from_balance, from]
+calldataload		# [amt, from_balance, from]
+dup1			# [amt, amt, from_balance, from]
 
-swap2			; [from_balance, amt, amt, from]
-sub			; [from_balance - amt, amt from]
-swap1			; [amt, from_balance - amt, from]
-swap2			; [from, from_balance - amt, amt]]
-sstore			; [amt]
+swap2			# [from_balance, amt, amt, from]
+sub			# [from_balance - amt, amt from]
+swap1			# [amt, from_balance - amt, from]
+swap2			# [from, from_balance - amt, amt]]
+sstore			# [amt]
 
-; increase to balance by amt
-push1 36		; [36, amt]
-calldataload		; [to, amt]
-dup1			; [to, to, amt]
-sload			; [to_balance, to, amt]
+# increase to balance by amt
+push1 36		# [36, amt]
+calldataload		# [to, amt]
+dup1			# [to, to, amt]
+sload			# [to_balance, to, amt]
 
-swap1			; [to, to_balance, amt]
-swap2			; [amt, to_balance, to]
-add			; [amt + to_balance, to]
-swap1			; [to, amt + to_balance]
+swap1			# [to, to_balance, amt]
+swap2			# [amt, to_balance, to]
+add			# [amt + to_balance, to]
+swap1			# [to, amt + to_balance]
 sstore
 
-; output event
-push1 36		; [36]
-calldataload		; [to]
-push1 4			; [4, to]
-calldataload		; [from, to]
-push1 68		; [68, from, to]
-calldataload		; [amt, from, to]
-push1 0			; [0, amt, from, to]
-mstore			; [from, to]
-push32 selector("Transfer(address,address,uint256)") ; [topic, from, to]
-push1 32		; [32, topic, from, to]
-push1 0			; [0, 32, topic, from, to]
+# output event
+push1 36		# [36]
+calldataload		# [to]
+push1 4			# [4, to]
+calldataload		# [from, to]
+push1 68		# [68, from, to]
+calldataload		# [amt, from, to]
+push1 0			# [0, amt, from, to]
+mstore			# [from, to]
+push32 topic("Transfer(address,address,uint256)") # [topic, from, to]
+push1 32		# [32, topic, from, to]
+push1 0			# [0, 32, topic, from, to]
 
-log3			; []
+log3			# []


### PR DESCRIPTION
Main breaking changes from `etk v0.2.0`:
* comments are now denoted with `#` instead of `;`
* `selector` only outputs 4 bytes, `topic` builtin is introduced to output full 32 bytes of digest